### PR TITLE
Add logging to transcription pipeline

### DIFF
--- a/modules/utils/logger.py
+++ b/modules/utils/logger.py
@@ -14,9 +14,12 @@ def get_logger(name: Optional[str] = None):
             "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
         )
 
-        handler = logging.StreamHandler()
-        # handler.setFormatter(formatter)
+        stream_handler = logging.StreamHandler()
+        stream_handler.setFormatter(formatter)
+        logger.addHandler(stream_handler)
 
-        logger.addHandler(handler)
+        file_handler = logging.FileHandler("webui.log")
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
 
     return logger

--- a/modules/whisper/faster_whisper_inference.py
+++ b/modules/whisper/faster_whisper_inference.py
@@ -64,12 +64,14 @@ class FasterWhisperInference(BaseTranscriptionPipeline):
         elapsed_time: float
             elapsed time for transcription
         """
+        logger.info("Transcribe called")
         start_time = time.time()
 
         params = WhisperParams.from_list(list(whisper_params))
 
         if params.model_size != self.current_model_size or self.model is None or self.current_compute_type != params.compute_type:
             self.update_model(params.model_size, params.compute_type, progress)
+            logger.info(f"Model set to {params.model_size} ({params.compute_type})")
 
         segments, info = self.model.transcribe(
             audio=audio,
@@ -112,6 +114,7 @@ class FasterWhisperInference(BaseTranscriptionPipeline):
             segments_result.append(Segment.from_faster_whisper(segment))
 
         elapsed_time = time.time() - start_time
+        logger.info(f"Transcription done in {elapsed_time:.2f}s")
         return segments_result, elapsed_time
 
     def update_model(self,
@@ -133,6 +136,7 @@ class FasterWhisperInference(BaseTranscriptionPipeline):
         progress: gr.Progress
             Indicator to show progress directly in gradio.
         """
+        logger.info(f"Loading model {model_size} with compute_type {compute_type}")
         progress(0, desc="Initializing Model..")
 
         model_size_dirname = model_size.replace("/", "--") if "/" in model_size else model_size
@@ -163,6 +167,7 @@ class FasterWhisperInference(BaseTranscriptionPipeline):
             compute_type=self.current_compute_type,
             local_files_only=local_files_only
         )
+        logger.info("Model initialized")
 
     def get_model_paths(self):
         """


### PR DESCRIPTION
## Summary
- output logs to both console and file
- report audio processing steps in BaseTranscriptionPipeline
- add progress logs in FasterWhisperInference

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686be4e74a9c8325aa054cfa4800e217